### PR TITLE
Avoid converting empty path to absolute path in AddPathSuffix()

### DIFF
--- a/src/Gemstone/IO/FilePath.cs
+++ b/src/Gemstone/IO/FilePath.cs
@@ -1042,7 +1042,7 @@ public static class FilePath
     {
         if (string.IsNullOrEmpty(filePath))
         {
-            filePath = Path.DirectorySeparatorChar.ToString();
+            filePath = "." + Path.DirectorySeparatorChar;
         }
         else
         {


### PR DESCRIPTION
This resolves the issue reported in:
https://discussions.gridprotectionalliance.org/t/issues-parsing-comtrade-files-cfg-dat-with-gemstone-comtrade/1257

The problem can basically be summed up with the following example.

```c#
string filePath = "filename.dat";
string directoryName = FilePath.GetDirectoryName(filePath); // returns @"\"
string fileName = FilePath.GetFileName(filePath);           // returns "filename.dat"
Console.WriteLine(Path.Combine(directoryName, fileName));   // prints @"\filename.dat"
```

`filename.dat` is a relative path in the working directory, whereas `\filename.dat` is an absolute path in the root directory so the resulting paths are not equivalent.