### PR TITLE
Fix INI description parsing dropping descriptions containing "word="

### DIFF
--- a/src/Gemstone/Configuration/Settings.cs
+++ b/src/Gemstone/Configuration/Settings.cs
@@ -503,7 +503,11 @@ public partial class Settings : DynamicObject
         Instance = settings;
     }
     
-    private const string INIKeyValuePairPattern = @";?\s*(?<key>\w+)\s*=.*";
+    // Anchored at the start of the line so a description comment that merely *contains* a "word="
+    // sequence (e.g. "...is set to Enabled=false in the database...") is not misinterpreted as a
+    // key/value pair. Without the leading '^', Regex.Match scans the whole line and matches the
+    // embedded "Enabled=false", which causes the real description above the setting to be dropped.
+    private const string INIKeyValuePairPattern = @"^;?\s*(?<key>\w+)\s*=.*";
     private static readonly Regex s_iniKeyValuePair;
 
     static Settings()


### PR DESCRIPTION
Settings.Bind() re-reads settings.ini to recover setting descriptions from the comment lines above each key. The detection regex (INIKeyValuePairPattern) was unanchored, so Regex.Match scanned the entire line and matched any embedded "word=" sequence -- a description such as "...is set to Enabled=false in the database..." was misclassified as a key/value pair, causing the real description for the following setting to be discarded.

Anchor the pattern at the start of the line ('^') so only lines that actually begin with an (optionally commented) key=value are treated as settings. This fixes both the GeneratedRegex (NET) and Regex (non-NET) paths since they share the constant.